### PR TITLE
Be more conservative about determining test assemblies

### DIFF
--- a/src/SonarAnalyzer.Common/Helpers/ProjectTypeHelper.cs
+++ b/src/SonarAnalyzer.Common/Helpers/ProjectTypeHelper.cs
@@ -29,19 +29,9 @@ namespace SonarAnalyzer.Helpers
     {
         public static bool IsTest(this Compilation compilation)
         {
-            var assemblyName = string.Empty;
-            if (compilation.AssemblyName != null)
-            {
-                assemblyName = compilation.AssemblyName;
-            }
-
-            return
-                assemblyName.ToUpperInvariant().Contains(TestAssemblyNamePattern) ||
-                compilation.ReferencedAssemblyNames
-                    .Any(assembly => TestAssemblyNames.Contains(assembly.Name.ToUpperInvariant()));
+            return compilation.ReferencedAssemblyNames
+                       .Any(assembly => TestAssemblyNames.Contains(assembly.Name.ToUpperInvariant()));
         }
-
-        private const string TestAssemblyNamePattern = "TEST";
 
         private static readonly ISet<string> TestAssemblyNames = ImmutableHashSet.Create(
             "MICROSOFT.VISUALSTUDIO.QUALITYTOOLS.UNITTESTFRAMEWORK",


### PR DESCRIPTION
The current `IsTest` method will match an assembly with the name `FastestProject `simply because `test` is in the name. I think it would be better to err on the side of caution and run analysis on such assemblies as they may not be test assemblies.

An alternative which I'd probably favour more would be to allow a regex to be supplied in a configuration file, although I'm not sure where this would best be placed.